### PR TITLE
Use retryablehttp for retrieving secrets from azure

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/Sirupsen/logrus v1.0.3
 	github.com/aokoli/goutils v1.0.1 // indirect
 	github.com/google/uuid v1.0.0 // indirect
+	github.com/hashicorp/go-retryablehttp v0.6.8
 	github.com/hashicorp/vault/api v1.0.4
 	github.com/huandu/xstrings v1.2.0 // indirect
 	github.com/imdario/mergo v0.3.6 // indirect

--- a/go.sum
+++ b/go.sum
@@ -38,12 +38,15 @@ github.com/hashicorp/go-cleanhttp v0.5.1 h1:dH3aiDG9Jvb5r5+bYHsikaOUIpcM0xvgMXVo
 github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
 github.com/hashicorp/go-hclog v0.0.0-20180709165350-ff2cf002a8dd/go.mod h1:9bjs9uLqI8l75knNv3lV1kA55veR+WUPSiKIWcQHudI=
 github.com/hashicorp/go-hclog v0.8.0/go.mod h1:5CU+agLiy3J7N7QjHK5d05KxGsuXiQLrjA0H7acj2lQ=
+github.com/hashicorp/go-hclog v0.9.2/go.mod h1:5CU+agLiy3J7N7QjHK5d05KxGsuXiQLrjA0H7acj2lQ=
 github.com/hashicorp/go-immutable-radix v1.0.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
 github.com/hashicorp/go-multierror v1.0.0 h1:iVjPR7a6H0tWELX5NxNe7bYopibicUzc7uPribsnS6o=
 github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHhCYQXV3UM06sGGrk=
 github.com/hashicorp/go-plugin v1.0.1/go.mod h1:++UyYGoz3o5w9ZzAdZxtQKrWWP+iqPBn3cQptSMzBuY=
 github.com/hashicorp/go-retryablehttp v0.5.4 h1:1BZvpawXoJCWX6pNtow9+rpEj+3itIlutiqnntI6jOE=
 github.com/hashicorp/go-retryablehttp v0.5.4/go.mod h1:9B5zBasrRhHXnJnui7y6sL7es7NDiJgTc6Er0maI1Xs=
+github.com/hashicorp/go-retryablehttp v0.6.8 h1:92lWxgpa+fF3FozM4B3UZtHZMJX8T5XT+TFdCxsPyWs=
+github.com/hashicorp/go-retryablehttp v0.6.8/go.mod h1:vAew36LZh98gCBJNLH42IQ1ER/9wtLZZ8meHqQvEYWY=
 github.com/hashicorp/go-rootcerts v1.0.1 h1:DMo4fmknnz0E0evoNYnV48RjWndOsmd6OW+09R3cEP8=
 github.com/hashicorp/go-rootcerts v1.0.1/go.mod h1:pqUvnprVnM5bf7AOirdbb01K4ccR319Vf4pU3K5EGc8=
 github.com/hashicorp/go-sockaddr v1.0.2 h1:ztczhD1jLxIRjVejw8gFomI1BQZOe2WoVOu0SyteCQc=

--- a/internal/world/azure.go
+++ b/internal/world/azure.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/Sirupsen/logrus"
+	"github.com/hashicorp/go-retryablehttp"
 	"github.com/pkg/errors"
 )
 
@@ -165,7 +166,9 @@ func (a *Azure) doVaultRequest(urlPath string) ([]byte, error) {
 	}
 	r.Header.Add("Authorization", fmt.Sprintf("Bearer %s", a.token))
 
-	client := &http.Client{}
+	retryClient := retryablehttp.NewClient()
+	client := retryClient.StandardClient()
+
 	resp, err := client.Do(r)
 	if err != nil {
 		return nil, errors.Wrap(err, "request failed")
@@ -194,7 +197,9 @@ func (a *Azure) getBearerToken() error {
 		return errors.Wrap(err, "request generation failed for token")
 	}
 
-	client := &http.Client{}
+	retryClient := retryablehttp.NewClient()
+	client := retryClient.StandardClient()
+
 	resp, err := client.Do(r)
 	if err != nil {
 		return errors.Wrap(err, "token request failed")

--- a/internal/world/azure.go
+++ b/internal/world/azure.go
@@ -158,12 +158,14 @@ func (a *Azure) doVaultRequest(urlPath string) ([]byte, error) {
 	}
 	u.Path = urlPath
 	u.RawQuery = params.Encode()
-	client := &http.Client{}
+
 	r, err := http.NewRequest("GET", u.String(), nil)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to generate request")
 	}
 	r.Header.Add("Authorization", fmt.Sprintf("Bearer %s", a.token))
+
+	client := &http.Client{}
 	resp, err := client.Do(r)
 	if err != nil {
 		return nil, errors.Wrap(err, "request failed")
@@ -186,11 +188,13 @@ func (a *Azure) getBearerToken() error {
 		return errors.Wrap(err, "failed to parse login URL")
 	}
 	u.Path = fmt.Sprintf("/%s/oauth2/token", a.tenantId)
-	client := &http.Client{}
+
 	r, err := http.NewRequest("POST", u.String(), strings.NewReader(params.Encode()))
 	if err != nil {
 		return errors.Wrap(err, "request generation failed for token")
 	}
+
+	client := &http.Client{}
 	resp, err := client.Do(r)
 	if err != nil {
 		return errors.Wrap(err, "token request failed")

--- a/internal/world/azure.go
+++ b/internal/world/azure.go
@@ -58,6 +58,38 @@ type Azure struct {
 	token        string
 }
 
+// LeveledLogrus implements the retryablehttp LeveledLogger interface
+// to use logrus as logging backend. See:
+// https://github.com/hashicorp/go-retryablehttp/pull/101#issuecomment-735206810
+type LeveledLogrus struct {
+	*logrus.Logger
+}
+
+func (l *LeveledLogrus) fields(keysAndValues ...interface{}) map[string]interface{} {
+	fields := make(map[string]interface{})
+
+	for i := 0; i < len(keysAndValues)-1; i += 2 {
+		fields[keysAndValues[i].(string)] = keysAndValues[i+1]
+	}
+
+	return fields
+}
+
+func (l *LeveledLogrus) Error(msg string, keysAndValues ...interface{}) {
+	l.WithFields(l.fields(keysAndValues...)).Error(msg)
+}
+
+func (l *LeveledLogrus) Info(msg string, keysAndValues ...interface{}) {
+	l.WithFields(l.fields(keysAndValues...)).Info(msg)
+}
+func (l *LeveledLogrus) Debug(msg string, keysAndValues ...interface{}) {
+	l.WithFields(l.fields(keysAndValues...)).Debug(msg)
+}
+
+func (l *LeveledLogrus) Warn(msg string, keysAndValues ...interface{}) {
+	l.WithFields(l.fields(keysAndValues...)).Warn(msg)
+}
+
 func (w *World) Azure() *Azure {
 	if w.azure != nil {
 		return w.azure
@@ -167,6 +199,7 @@ func (a *Azure) doVaultRequest(urlPath string) ([]byte, error) {
 	r.Header.Add("Authorization", fmt.Sprintf("Bearer %s", a.token))
 
 	retryClient := retryablehttp.NewClient()
+	retryClient.Logger = &LeveledLogrus{a.logger}
 	client := retryClient.StandardClient()
 
 	resp, err := client.Do(r)
@@ -198,6 +231,7 @@ func (a *Azure) getBearerToken() error {
 	}
 
 	retryClient := retryablehttp.NewClient()
+	retryClient.Logger = &LeveledLogrus{a.logger}
 	client := retryClient.StandardClient()
 
 	resp, err := client.Do(r)


### PR DESCRIPTION
During our builds we suffer from io timeouts when fetching secrets. 

Therefore, I replaced the stdlib http client with a client retrieved via retryablehttp. 